### PR TITLE
replace set-output and update tizen cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.1.0 (August 9, 2023)
+ * Update Tizen CLI to v5.1
+ * Replace ::set-output (deprecated)
 # v1.0.1 (October 1, 2021)
  * VV-44 - Alter script permissions
  

--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,9 @@
 # Set up Tizen Studio
 #
 TIZEN_STUDIO="$GITHUB_WORKSPACE/tizen-studio"
-INSTALLER="$GITHUB_WORKSPACE/tizen-studio_4.1.1.bin"
+INSTALLER="$GITHUB_WORKSPACE/tizen-studio_5.1.bin"
 
-wget -nc -O "$INSTALLER"  http://download.tizen.org/sdk/Installer/tizen-studio_4.1.1/web-cli_Tizen_Studio_4.1.1_ubuntu-64.bin
+wget -nc -O "$INSTALLER"  http://download.tizen.org/sdk/Installer/tizen-studio_5.1/web-cli_Tizen_Studio_5.1_ubuntu-64.bin
 chmod a+x "$INSTALLER"
 "$INSTALLER" --accept-license $TIZEN_STUDIO
 
@@ -88,7 +88,7 @@ tizen build-web -- "$PROJECT_DIR" \
 
 if [ $? -eq 0 ]; then
     SUCCESS=true
-    echo "::set-output name=package-artifact::$PACKAGE_OUTPUT_PATH"
+    echo "package-artifact=$PACKAGE_OUTPUT_PATH" >> $GITHUB_OUTPUT
 else
     SUCCESS=false
     cat "$ERROR_LOG"


### PR DESCRIPTION
set-output is deprecated for Github Actions. I replaced it with the new method (>> $GITHUB_OUTPUT). More information here:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I updated the web Tizen cli to version 5.1 also. No changes regarding the action usage necessary.
Hint: If you cache the Tizen cli instance, then you may need to adjust the cache key.