### PR TITLE
change set-output to GITHUB_OUTPUT

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ tizen build-web -- "$PROJECT_DIR" \
 
 if [ $? -eq 0 ]; then
     SUCCESS=true
-    echo "::set-output name=package-artifact::$PACKAGE_OUTPUT_PATH"
+    echo "package-artifact=$PACKAGE_OUTPUT_PATH" >> $GITHUB_OUTPUT
 else
     SUCCESS=false
     cat "$ERROR_LOG"


### PR DESCRIPTION
set-output is deprecated for Github Actions. I replaced it with the new method (>> $GITHUB_OUTPUT). More information here:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
