### PR TITLE
fix: proper comparison for string

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ PATH="$TIZEN_STUDIO/tools/ide/bin:$PATH"
 #
 # Parse arguments
 #
-if [$8 -eq 'partner']; then
+if [ "$8" = "partner" ]; then
     PRIVILEGE=parner
 else
     PRIVILEGE=public


### PR DESCRIPTION
```
/home/runner/work/_actions/xxx/tizen-build-action/v1/build.sh: line 16: [public: command not found
```

fixes: #9 