### PR TITLE
build: lint bash files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      time: "08:00"
+      timezone: "America/New_York"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,16 @@
+name: tizen-build-action lint
+on:
+  push:
+  pull_request:
+
+jobs:
+  bash-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Lint Bash
+        uses: azohra/shell-linter@latest
+        with:
+          path: '*.sh'

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ INSTALLER="$GITHUB_WORKSPACE/tizen-studio_5.1.bin"
 
 wget -nc -O "$INSTALLER"  http://download.tizen.org/sdk/Installer/tizen-studio_5.1/web-cli_Tizen_Studio_5.1_ubuntu-64.bin
 chmod a+x "$INSTALLER"
-"$INSTALLER" --accept-license $TIZEN_STUDIO
+"$INSTALLER" --accept-license "$TIZEN_STUDIO"
 
 PATH="$TIZEN_STUDIO/tools/ide/bin:$PATH"
 
@@ -21,7 +21,7 @@ fi
 
 PROJECT_DIR="$1"
 
-if [ ! -z $2 ]; then
+if [ -n "$2" ]; then
     CUSTOM_AUTHOR_CERT="$GITHUB_WORKSPACE/author-cert.cer"
     echo -n "$2" | base64 -d >"$CUSTOM_AUTHOR_CERT"
 fi
@@ -33,14 +33,14 @@ echo -n "$3" | base64 -d >"$AUTHOR_KEY"
 
 AUTHOR_PASSWORD="$4"
 
-if [ ! -z $5 ]; then
+if [ -n "$5" ]; then
     CUSTOM_DISTRIBUTOR_CERT="$GITHUB_WORKSPACE/distributor-cert.cer"
     echo -n "$5" | base64 -d >"$CUSTOM_DISTRIBUTOR_CERT"
 fi
 DEFAULT_DISTRIBUTOR_CERT="$TIZEN_STUDIO/tools/certificate-generator/certificates/distributor/sdk-$PRIVILEGE/tizen-distributor-ca.cer"
 DISTRIBUTOR_CERT="${CUSTOM_DISTRIBUTOR_CERT:-"$DEFAULT_DISTRIBUTOR_CERT"}"
 
-if [ ! -z $6 ]; then
+if [ -n "$6" ]; then
     CUSTOM_DISTRIBUTOR_KEY="$GITHUB_WORKSPACE/distributor-key.p12"
     echo -n "$6" | base64 -d >"$CUSTOM_DISTRIBUTOR_KEY"
 fi
@@ -49,7 +49,7 @@ DISTRIBUTOR_KEY="${CUSTOM_DISTRIBUTOR_KEY:-"$DEFAULT_DISTRIBUTOR_KEY"}"
 
 DISTRIBUTOR_PASSWORD="${7:-tizenpkcs12passfordsigner}"
 
-echo <<EOF
+cat <<EOF
 Build and signing parameters:
  - project-dir: $PROJECT_DIR
  - author-cert: $AUTHOR_CERT
@@ -86,9 +86,10 @@ ERROR_LOG="$GITHUB_WORKSPACE/tizen-studio-data/cli/logs/cli.log"
 tizen build-web -- "$PROJECT_DIR" \
     && tizen package -t wgt -s sourcetoad-tizen-public -o "$PACKAGE_OUTPUT_PATH" -- "$PROJECT_DIR/.buildResult"
 
+# shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
     SUCCESS=true
-    echo "package-artifact=$PACKAGE_OUTPUT_PATH" >> $GITHUB_OUTPUT
+    echo "package-artifact=$PACKAGE_OUTPUT_PATH" >> "$GITHUB_OUTPUT"
 else
     SUCCESS=false
     cat "$ERROR_LOG"

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Set up Tizen Studio
 #


### PR DESCRIPTION
Knowing some of our mistakes in past releases were from simple bash errors. This should help prevent regressions as we revisit this action.